### PR TITLE
Continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,11 @@ jobs:
     - restore_cache:
         keys:
         - v1-pkg-cache
-    - run: go get github.com/jstemmer/go-junit-report
+    - run:
+        name: Install dependencies
+        command: |
+          go get github.com/jstemmer/go-junit-report
+          apt-get install -y librdkafka-dev
     - run:
         name: Test
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
         name: Install dependencies
         command: |
           go get github.com/jstemmer/go-junit-report
-          sudo apt-get install -y librdkafka-dev
+          echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" | sudo tee /etc/apt/sources.list.d/backports.list
+          sudo apt-get update
+          sudo apt-get install -y librdkafka-dev/stretch-backports
     - run:
         name: Test
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         name: Test
         command: |
           trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-          go test -v . -coverprofile=$(TEST_RESULTS)/coverage.out | tee ${TEST_RESULTS}/go-test.out
+          go test -v . -coverprofile=${TEST_RESULTS}/coverage.out | tee ${TEST_RESULTS}/go-test.out
     - save_cache:
         key: v1-pkg-cache
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
         name: Install dependencies
         command: |
           go get github.com/jstemmer/go-junit-report
-          apt-get install -y librdkafka-dev
+          sudo apt-get install -y librdkafka-dev
     - run:
         name: Test
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+    - image: circleci/golang:1.11.1
+    environment:
+      TEST_RESULTS: /tmp/test-results
+    steps:
+    - checkout
+    - run: mkdir -p $TEST_RESULTS
+    - restore_cache:
+        keys:
+        - v1-pkg-cache
+    - run: go get github.com/jstemmer/go-junit-report
+    - run:
+        name: Test
+        command: |
+          trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+          go test -v . -coverprofile=$(TEST_RESULTS)/coverage.out | tee ${TEST_RESULTS}/go-test.out
+    - save_cache:
+        key: v1-pkg-cache
+        paths:
+        - "/go/pkg"
+    - run:
+        name: Coverage
+        command: go tool cover -html=${TEST_RESULTS}/coverage.out -o=${TEST_RESULTS}/coverage.html
+    - store_artifacts:
+        path: /tmp/test-results
+        destination: raw-test-output
+    - store_test_results:
+        path: /tmp/test-results


### PR DESCRIPTION
Since circleci golang images are based on Debian stretch I had to use backports to get recent version of librdkafka-dev