### PR TITLE
Implement decoder from native types to struct

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,0 +1,125 @@
+package kafkaavro
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type NativeDecoder interface {
+	FromNative(interface{}) error
+}
+
+var nativeDecoderType = reflect.TypeOf((*NativeDecoder)(nil)).Elem()
+
+func DecodeRecordFromNative(src interface{}, dst interface{}) error {
+	record, ok := src.(map[string]interface{})
+	if !ok {
+		return errors.New("record type assertion failed")
+	}
+	structValue := reflect.ValueOf(dst).Elem()
+	for key, data := range record {
+		dstField := structValue.FieldByNameFunc(func(name string) bool {
+			return strings.ToLower(key) == strings.ToLower(name)
+		})
+
+		if !dstField.IsValid() {
+			continue
+		}
+
+		err := valueFromNative(data, dstField)
+		if err != nil {
+			return errors.Wrapf(err, "field %s", key)
+		}
+	}
+	return nil
+}
+
+func decodeSliceFromNative(src interface{}, dstVal reflect.Value) error {
+	if reflect.TypeOf(src).Kind() != reflect.Slice {
+		return errors.New("source type is not slice")
+	}
+	srcVal := reflect.ValueOf(src)
+	dstVal.Set(reflect.MakeSlice(dstVal.Type(), srcVal.Len(), srcVal.Len()))
+	for i := 0; i < srcVal.Len(); i++ {
+		err := valueFromNative(srcVal.Index(i).Interface(), dstVal.Index(i))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+
+
+func valueFromNative(src interface{}, value reflect.Value) error {
+	sv := reflect.ValueOf(src)
+
+	valueTypeKind := value.Type().Kind()
+
+	if valueTypeKind == reflect.Slice {
+		return decodeSliceFromNative(src, value)
+	}
+
+	// Check if value is a pointer and implements NativeDecoder
+	if valueTypeKind == reflect.Ptr && value.Type().Implements(nativeDecoderType) {
+		if value.IsNil() {
+			value.Set(reflect.New(value.Type().Elem()))
+		}
+		err := value.Interface().(NativeDecoder).FromNative(src)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Check if value is a pointer to a struct
+	if valueTypeKind == reflect.Ptr && value.Type().Elem().Kind() == reflect.Struct {
+		if src == nil && value.IsNil() {
+			return nil
+		}
+		if src == nil && !value.IsNil() {
+			value.Set(reflect.Zero(value.Type()))
+			return nil
+		}
+		if value.IsNil() {
+			value.Set(reflect.New(value.Type().Elem()))
+		}
+		// Set fields for optional struct
+		// That means source is a map with single field corresponding with record type
+		srcMap, ok := src.(map[string]interface{})
+		if !ok || len(srcMap) != 1 {
+			return errors.Errorf("missing record %v", src)
+		}
+		for _, srcMapVal := range srcMap {
+			return DecodeRecordFromNative(srcMapVal, value.Interface())
+		}
+		return nil
+	}
+	// Check if value is not a pointer and implements NativeDecoder
+	if valueTypeKind != reflect.Ptr && reflect.PtrTo(value.Type()).Implements(nativeDecoderType) {
+		err := value.Addr().Interface().(NativeDecoder).FromNative(src)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Check if value is a struct
+	if valueTypeKind == reflect.Struct && sv.Kind() == reflect.Map {
+		return DecodeRecordFromNative(src, value.Addr().Interface())
+	}
+
+	if sv.IsValid() && sv.Type().AssignableTo(value.Type()) {
+		value.Set(sv)
+		return nil
+	}
+
+	if value.Kind() == sv.Kind() && sv.Type().ConvertibleTo(value.Type()) {
+		value.Set(sv.Convert(value.Type()))
+		return nil
+	}
+
+	return errors.Errorf("%s type is not %s", reflect.TypeOf(src), value.Type())
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,222 @@
+package kafkaavro_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mycujoo/go-kafka-avro"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeFromNative(t *testing.T) {
+	dt := time.Date(2018, 01, 01, 0, 0, 0, 0, time.UTC)
+
+	type NestedStruct struct {
+		NestedField string
+	}
+
+	type withString struct {
+		Field string
+	}
+	type withPtr struct {
+		Field *NestedStruct
+	}
+	type withStruct struct {
+		Field NestedStruct
+	}
+	type withSlice struct {
+		Field []int
+	}
+	type withOptionalString struct {
+		Field kafkaavro.OptionalString
+	}
+	type withPtrOptionalString struct {
+		Field *kafkaavro.OptionalString
+	}
+	type withOptionalInt struct {
+		Field kafkaavro.OptionalInt
+	}
+	type withOptionalDay struct {
+		Field kafkaavro.OptionalDay
+	}
+	type withUInt8 struct {
+		Field uint8
+	}
+
+	val4 := kafkaavro.NewOptionalString("val4", true)
+
+	testCases := map[string]struct {
+		src      interface{}
+		dst      interface{}
+		expected interface{}
+	}{
+		"string field": {
+			src: map[string]interface{}{
+				"field": "val1",
+			},
+			dst: &withString{},
+			expected: &withString{
+				Field: "val1",
+			},
+		},
+		"struct ptr to nil": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{
+					"nestedRecord": map[string]interface{}{
+						"nestedField": "val2",
+					},
+				},
+			},
+			dst: &withPtr{},
+			expected: &withPtr{
+				Field: &NestedStruct{
+					NestedField: "val2",
+				},
+			},
+		},
+		"struct ptr to not nil": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{
+					"nestedRecord": map[string]interface{}{
+						"nestedField": "val3",
+					},
+				},
+			},
+			dst: &withPtr{
+				Field: &NestedStruct{
+					NestedField: "val2",
+				},
+			},
+			expected: &withPtr{
+				Field: &NestedStruct{
+					NestedField: "val3",
+				},
+			},
+		},
+		"struct ptr nil to not nil": {
+			src: map[string]interface{}{
+				"field": nil,
+			},
+			dst: &withPtr{
+				Field: &NestedStruct{
+					NestedField: "val2",
+				},
+			},
+			expected: &withPtr{
+				Field: nil,
+			},
+		},
+		"struct ptr nil to nil": {
+			src: map[string]interface{}{
+				"field": nil,
+			},
+			dst: &withPtr{},
+			expected: &withPtr{
+				Field: nil,
+			},
+		},
+		"struct": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{
+					"nestedField": "val3",
+				},
+			},
+			dst: &withStruct{},
+			expected: &withStruct{
+				Field: NestedStruct{
+					NestedField: "val3",
+				},
+			},
+		},
+		"slice": {
+			src: map[string]interface{}{
+				"field": []int{1, 2, 3, 4},
+			},
+			dst: &withSlice{},
+			expected: &withSlice{
+				Field: []int{1, 2, 3, 4},
+			},
+		},
+		"nil optional string": {
+			src: map[string]interface{}{
+				"field": nil,
+			},
+			dst: &withOptionalString{},
+			expected: &withOptionalString{
+				Field: kafkaavro.NewOptionalString("", false),
+			},
+		},
+		"not nil optional string": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{"string": "val4"},
+			},
+			dst: &withOptionalString{},
+			expected: &withOptionalString{
+				Field: val4,
+			},
+		},
+		"not nil ptr to optional string": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{"string": "val4"},
+			},
+			dst: &withPtrOptionalString{},
+			expected: &withPtrOptionalString{
+				Field: &val4,
+			},
+		},
+		"extra fields ignored": {
+			src: map[string]interface{}{
+				"field": "test",
+				"extraField": "extra",
+			},
+			dst: &withString{},
+			expected: &withString{
+				Field: "test",
+			},
+		},
+		"nil optional int": {
+			src: map[string]interface{}{
+				"field": nil,
+			},
+			dst: &withOptionalInt{},
+			expected: &withOptionalInt{
+				Field: kafkaavro.NewOptionalInt(0, false),
+			},
+		},
+		"not nil optional int": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{"int": int32(123)},
+			},
+			dst: &withOptionalInt{},
+			expected: &withOptionalInt{
+				Field: kafkaavro.NewOptionalInt(123, true),
+			},
+		},
+		"not nil optional day": {
+			src: map[string]interface{}{
+				"field": map[string]interface{}{"int.date": dt},
+			},
+			dst: &withOptionalDay{},
+			expected: &withOptionalDay{
+				Field: kafkaavro.NewOptionalDay(dt, true),
+			},
+		},
+		"convert byte": {
+			src: map[string]interface{}{
+				"field": byte(32),
+			},
+			dst: &withUInt8{},
+			expected: &withUInt8{
+				Field: 32,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := kafkaavro.DecodeRecordFromNative(tc.src, tc.dst)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, tc.dst)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,12 @@ module github.com/mycujoo/go-kafka-avro
 
 require (
 	github.com/confluentinc/confluent-kafka-go v0.11.6
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/landoop/schema-registry v0.0.0-20180614054439-8473163e8587
 	github.com/linkedin/goavro v0.0.0-20181018120728-1beee2a74088
 	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+	gopkg.in/guregu/null.v3 v3.4.0
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/confluentinc/confluent-kafka-go v0.11.6 h1:rEblubnNXCjRThwAGnFSzLKYIRAoXLDC3A9r4ciziHU=
 github.com/confluentinc/confluent-kafka-go v0.11.6/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/landoop/schema-registry v0.0.0-20180614054439-8473163e8587 h1:z5RQnj+2TtCS4OvIbk6OeduSNb33i271L/5O4xqCgMI=
@@ -8,5 +10,11 @@ github.com/linkedin/goavro v0.0.0-20181018120728-1beee2a74088 h1:T+kPxsfvkFtz7x6
 github.com/linkedin/goavro v0.0.0-20181018120728-1beee2a74088/go.mod h1:vL3ODoWTPCBSeKVFgQ+lvSq0VOzTB5TcXvUX+4pU/+Q=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+gopkg.in/guregu/null.v3 v3.4.0 h1:AOpMtZ85uElRhQjEDsFx21BkXqFPwA7uoJukd4KErIs=
+gopkg.in/guregu/null.v3 v3.4.0/go.mod h1:E4tX2Qe3h7QdL+uZ3a0vqvYwKQsRSQKM5V4YltdgH9Y=
 gopkg.in/linkedin/goavro.v1 v1.0.5 h1:BJa69CDh0awSsLUmZ9+BowBdokpduDZSM9Zk8oKHfN4=
 gopkg.in/linkedin/goavro.v1 v1.0.5/go.mod h1:Aw5GdAbizjOEl0kAMHV9iHmA8reZzW/OKuJAl4Hb9F0=

--- a/optionalday.go
+++ b/optionalday.go
@@ -1,0 +1,56 @@
+package kafkaavro
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type OptionalDay struct {
+	Valid bool
+	Time  time.Time
+}
+
+func NewOptionalDay(t time.Time, valid bool) OptionalDay {
+	return OptionalDay{
+		Valid: valid,
+		Time:  t,
+	}
+}
+
+func (od *OptionalDay) FromNative(data interface{}) error {
+	// value is null
+	if data == nil {
+		od.Valid = false
+		od.Time = time.Unix(0, 0)
+		return nil
+	}
+
+	// otherwise it is a record with a field "int"
+	m, ok := data.(map[string]interface{})
+
+	if !ok {
+		return errors.New("OptionalDay data not a record")
+	}
+
+	val, ok := m["int.date"]
+	if !ok {
+		return errors.New("OptionalDay record missing int field")
+	}
+	t, ok := val.(time.Time)
+	if !ok {
+		return errors.New("OptionalDay value type mismatch")
+	}
+
+	od.Valid = true
+	od.Time = t
+	return nil
+}
+
+func (od OptionalDay) MarshalJSON() ([]byte, error) {
+	if !od.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(od.Time.Format("2006-01-02"))
+}

--- a/optionalint.go
+++ b/optionalint.go
@@ -1,0 +1,45 @@
+package kafkaavro
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/guregu/null.v3"
+)
+
+type OptionalInt struct {
+	null.Int
+}
+
+func NewOptionalInt(i int64, valid bool) OptionalInt {
+	return OptionalInt{
+		Int: null.NewInt(i, valid),
+	}
+}
+
+func (i *OptionalInt) FromNative(data interface{}) error {
+	// value is null
+	if data == nil {
+		i.Int.Valid = false
+		i.Int.Int64 = 0
+		return nil
+	}
+
+	// otherwise it is a record with a field "int"
+	m, ok := data.(map[string]interface{})
+
+	if !ok {
+		return errors.New("OptionalInt data not a record")
+	}
+
+	val, ok := m["int"]
+	if !ok {
+		return errors.New("OptionalInt record missing int field")
+	}
+	intVal, ok := val.(int32)
+	if !ok {
+		return errors.New("OptionalInt int type mismatch")
+	}
+
+	i.Int.Valid = true
+	i.Int.Int64 = int64(intVal)
+	return nil
+}

--- a/optionalstring.go
+++ b/optionalstring.go
@@ -1,0 +1,45 @@
+package kafkaavro
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/guregu/null.v3"
+)
+
+type OptionalString struct {
+	null.String
+}
+
+func NewOptionalString(s string, valid bool) OptionalString {
+	return OptionalString{
+		String: null.NewString(s, valid),
+	}
+}
+
+func (s *OptionalString) FromNative(data interface{}) error {
+	// value is null
+	if data == nil {
+		s.NullString.Valid = false
+		s.NullString.String = ""
+		return nil
+	}
+
+	// otherwise it is a record with a field "string"
+	m, ok := data.(map[string]interface{})
+
+	if !ok {
+		return errors.New("OptionalString data not a record")
+	}
+
+	val, ok := m["string"]
+	if !ok {
+		return errors.New("OptionalString record missing string field")
+	}
+	str, ok := val.(string)
+	if !ok {
+		return errors.New("OptionalString string type mismatch")
+	}
+
+	s.NullString.Valid = true
+	s.NullString.String = str
+	return nil
+}


### PR DESCRIPTION
This PR will implement decoder that can convert from Go native types like map/slice to structures using reflection.

We can improve it later by introducing field tags, etc.