### PR TITLE
Add retry logic with cenkalti/backoff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.1
+      - image: circleci/golang:1.12
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/README.md
+++ b/README.md
@@ -6,37 +6,42 @@ A wrapper for Confluent's libraries for [Apache Kafka](http://kafka.apache.org/)
 
 First install dependencies:
 
-	go get github.com/confluentinc/confluent-kafka-go github.com/landoop/schema-registry
+    go get github.com/confluentinc/confluent-kafka-go github.com/landoop/schema-registry
 
 To install use `go get`:
-	
-	go get github.com/mycujoo/go-kafka-avro
-	
-	
+
+    go get github.com/mycujoo/go-kafka-avro
+
 ## Usage
 
 First, you need to create cached schema registry client:
 
-	srClient, err := kafkaavro.NewCachedSchemaRegistryClient(baseurl)
-	
+    srClient, err := kafkaavro.NewCachedSchemaRegistryClient(baseurl)
+
 For more options look at [Landoop Schema Registry Client README](https://github.com/Landoop/schema-registry#client).
 
 ### Producer
 
 Create kafka producer:
 
-	kafkaProducer, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": "localhost"})
-	
+    kafkaProducer, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": "localhost"})
+
 Then construct you can construct one or more kafkaavro producers:
 
-	producer, err := kafkaavro.NewProducer("topic", "string", `{"type": "record", "name": "test", "fields" : [{"name": "val", "type": "int", "default": 0}]}`, kafkaProducer, srClient)
-	
+    producer, err := kafkaavro.NewProducer(kafkaavro.ProducerConfig{
+    	TopicName:            "topic",
+    	KeySchema:            `"string"`,
+    	ValueSchema:          `{"type": "record", "name": "test", "fields" : [{"name": "val", "type": "int", "default": 0}]}`,
+    	Producer:             kafkaProducer,
+    	SchemaRegistryClient: srClient,
+    })
+
 Publish message using `Produce` method:
 
-	err = producer.Produce("key", "value", nil)
-	
+    err = producer.Produce("key", "value", nil)
+
 If you provide deliverChan then call will not be blocking until delivery.
-	
+
 ## Supported go versions
 
 We support only latest version, which is 1.11 at the moment.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you provide deliverChan then call will not be blocking until delivery.
 
 ## Supported go versions
 
-We support only latest version, which is 1.11 at the moment.
+We support version >=1.12
 
 ## Related
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/mycujoo/go-kafka-avro
 go 1.11
 
 require (
+	github.com/cenkalti/backoff/v3 v3.1.1
 	github.com/confluentinc/confluent-kafka-go v1.1.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/landoop/schema-registry v0.0.0-20190327143759-50a5701c1891
 	github.com/linkedin/goavro v0.0.0-20181018120728-1beee2a74088
 	github.com/pkg/errors v0.8.1
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/guregu/null.v3 v3.4.0
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mycujoo/go-kafka-avro
 
-go 1.11
+go 1.12
 
 require (
 	github.com/cenkalti/backoff/v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
+github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/confluentinc/confluent-kafka-go v1.1.0 h1:HIW7Nkm8IeKRotC34mGY06DwQMf9Mp9PZMyqDxid2wI=
 github.com/confluentinc/confluent-kafka-go v1.1.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,7 +18,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/guregu/null.v3 v3.4.0 h1:AOpMtZ85uElRhQjEDsFx21BkXqFPwA7uoJukd4KErIs=

--- a/producer.go
+++ b/producer.go
@@ -3,6 +3,7 @@ package kafkaavro
 import (
 	"encoding/binary"
 
+	"github.com/cenkalti/backoff/v3"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/linkedin/goavro"
 	"github.com/pkg/errors"
@@ -26,60 +27,91 @@ type Producer struct {
 
 	avroKeyCodec   *goavro.Codec
 	avroValueCodec *goavro.Codec
+
+	backOffConfig backoff.BackOff
+}
+
+type ProducerConfig struct {
+	// Name of the topic where messages will be produced
+	TopicName string
+
+	// Avro schema for message key
+	KeySchema string
+
+	// Avro schema for message value
+	ValueSchema string
+
+	// Low level kafka producer used to produce messages
+	Producer kafkaProducer
+
+	// Schema registry client used for messages validation and schema management
+	SchemaRegistryClient SchemaRegistryClient
+
+	// BackOffConfig is used for setting backoff strategy for retry logic
+	BackOffConfig backoff.BackOff
 }
 
 // NewProducer is a producer that publishes messages to kafka topic using avro serialization format
-func NewProducer(topic string, keySchema string, valueSchema string, producer kafkaProducer, schemaRegistryClient SchemaRegistryClient) (*Producer, error) {
-	if producer == nil {
+func NewProducer(cfg ProducerConfig) (*Producer, error) {
+	if cfg.Producer == nil {
 		return nil, errors.New("missing producer")
 	}
-	if schemaRegistryClient == nil {
+
+	if cfg.SchemaRegistryClient == nil {
 		return nil, errors.New("missing schema registry client")
 	}
 
-	keyCodec, err := goavro.NewCodec(keySchema)
+	keyCodec, err := goavro.NewCodec(cfg.KeySchema)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot initialize key codec")
 	}
 
-	valueCodec, err := goavro.NewCodec(valueSchema)
+	valueCodec, err := goavro.NewCodec(cfg.ValueSchema)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot initialize value codec")
 	}
 
-	keySchemaID, err := schemaRegistryClient.RegisterNewSchema(topic+"-key", keyCodec)
+	schemaRegistrySubjectKey := cfg.TopicName + "-key"
+	keySchemaID, err := cfg.SchemaRegistryClient.RegisterNewSchema(schemaRegistrySubjectKey, keyCodec)
 	if err != nil {
 		return nil, err
 	}
-	valueSchemaID, err := schemaRegistryClient.RegisterNewSchema(topic+"-value", valueCodec)
+
+	schemaRegistrySubjectValue := cfg.TopicName + "-value"
+	valueSchemaID, err := cfg.SchemaRegistryClient.RegisterNewSchema(schemaRegistrySubjectValue, valueCodec)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Producer{
-		producer:       producer,
-		topicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+		producer: cfg.Producer,
+		topicPartition: kafka.TopicPartition{
+			Topic:     &cfg.TopicName,
+			Partition: kafka.PartitionAny,
+		},
 
-		schemaRegistryClient:       schemaRegistryClient,
-		schemaRegistrySubjectKey:   topic + "-key",
-		schemaRegistrySubjectValue: topic + "-value",
+		schemaRegistryClient:       cfg.SchemaRegistryClient,
+		schemaRegistrySubjectKey:   schemaRegistrySubjectKey,
+		schemaRegistrySubjectValue: schemaRegistrySubjectValue,
 
 		keySchemaID:   keySchemaID,
 		valueSchemaID: valueSchemaID,
 
 		avroKeyCodec:   keyCodec,
 		avroValueCodec: valueCodec,
+
+		backOffConfig: cfg.BackOffConfig,
 	}, nil
 }
 
 // Produce will try to publish message to a topic. If deliveryChan is provided then function will return immediately,
 // otherwise it will wait for delivery
-func (ap *Producer) Produce(key interface{}, value interface{}, deliveryChan chan kafka.Event) error {
-
+func (ap *Producer) produce(key interface{}, value interface{}, deliveryChan chan kafka.Event) error {
 	binaryKey, err := getAvroBinary(ap.keySchemaID, ap.avroKeyCodec, key)
 	if err != nil {
 		return err
 	}
+
 	binaryValue, err := getAvroBinary(ap.valueSchemaID, ap.avroValueCodec, value)
 	if err != nil {
 		return err
@@ -106,7 +138,18 @@ func (ap *Producer) Produce(key interface{}, value interface{}, deliveryChan cha
 			return m.TopicPartition.Error
 		}
 	}
+
 	return nil
+}
+
+func (ap *Producer) Produce(key interface{}, value interface{}, deliveryChan chan kafka.Event) error {
+	if ap.backOffConfig != nil {
+		return backoff.Retry(func() error {
+			return ap.produce(key, value, deliveryChan)
+		}, ap.backOffConfig)
+	}
+
+	return ap.produce(key, value, deliveryChan)
 }
 
 func getAvroBinary(schemaID int, codec *goavro.Codec, native interface{}) ([]byte, error) {

--- a/producer_test.go
+++ b/producer_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNewProducer(t *testing.T) {
-
 	kp, err := kafka.NewProducer(&kafka.ConfigMap{
 		"socket.timeout.ms":    1100,
 		"default.topic.config": kafka.ConfigMap{"message.timeout.ms": 10}})
@@ -18,7 +17,13 @@ func TestNewProducer(t *testing.T) {
 
 	srClient := &mockSchemaRegistryClient{}
 
-	p, err := kafkaavro.NewProducer("topic", "\"string\"", "\"string\"", kp, srClient)
+	p, err := kafkaavro.NewProducer(kafkaavro.ProducerConfig{
+		TopicName:            "topic",
+		KeySchema:            `"string"`,
+		ValueSchema:          `"string"`,
+		Producer:             kp,
+		SchemaRegistryClient: srClient,
+	})
 	if err != nil {
 		t.Fatalf("Error creating producer: %+v", err.Error())
 	}


### PR DESCRIPTION
Adds easy to use retry logic with https://github.com/cenkalti/backoff
- separate kafkaavro.NewProducer arguments to it's own struct ProducerConfig
- ProducerConfig will include backoff.Backoff interface field which when provided will be used for retrier