### PR TITLE
Fix ReadMessage nil handling

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -170,8 +170,10 @@ func (ac *Consumer) ReadMessage(timeoutMs int) (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err = ac.KafkaConsumer.CommitMessage(msg.Message); err != nil {
-		err = ErrFailedCommit{Err: err}
+	if msg != nil { // FetchMessage may return a nil msg
+		if _, err = ac.KafkaConsumer.CommitMessage(msg.Message); err != nil {
+			err = ErrFailedCommit{Err: err}
+		}
 	}
 	return msg, err
 }


### PR DESCRIPTION
This is pretty self-explanatory. `FetchMessage` has an explicit:

- `return nil, nil`: https://github.com/mycujoo/go-kafka-avro/pull/12/files#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R152-R154

which needs to be handled.